### PR TITLE
Improve typescript interface match

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -117,11 +117,12 @@ syn match styledPrefix "\.\<extend\>"
 " annotations (delimited by brackets (e.g. "<>")) between `styled` and
 " the function call parenthesis
 syn match styledTypescriptPrefix
-      \ "\<styled\><\%(\k\|'\|\"\|`\|,\|\s\)\+>(\%('\k\+'\|\"\k\+\"\|`\k\+`\))"
+      \ "\<styled\><\%({\|}\||\|&\|:\|;\|,\|'\|\"\|\k\|\s\|\n\)\+>(\%('\k\+'\|\"\k\+\"\))"
       \ transparent fold
       \ nextgroup=styledDefinition
       \ contains=cssTagName,
-      \          typescriptOpSymbols,typescriptEndColons,typescriptParens,
+      \          typescriptBraces,typescriptOpSymbols,typescriptEndColons,
+      \          typescriptParens,typescriptStringS,typescriptType,
       \          styledTagNameString
 
 " define emotion css prop

--- a/examples/typescript.ts
+++ b/examples/typescript.ts
@@ -31,5 +31,47 @@ const StyledSection = styled(Section)`
   align-items: center;
 `;
 
+interface ExistingInterface {
+  someAttribute: boolean;
+}
+
+const InterfaceComponent = styled<ExistingInterface, 'h1'>('h1')`
+  background-color: blue;
+  color: green;
+`;
+
+const InlineInterfaceComponent = styled<
+  someAttribute
+}, 'h1'>('h1')`
+  background-color: white;
+  color: black;
+`;
+
+const InlineInterfaceComponent = styled<{
+  someAttribute: {
+    someNestedAttribute: any;
+  }
+  anotherAttribute: any;
+}, 'h1'>('h1')`
+  background-color: black;
+  color: white;
+`;
+
+const ExtendedInterfaceComponent = styled<ExistingInterface & {
+  someAttribute: {
+    someNestedAttribute: any;
+  }
+  anotherAttribute: any;
+}, 'h1'>('h1')`
+  background-color: hotpink;
+  color: papayawhip;
+`;
+
+const AlternativeInterfaceComponent = styled<ExistingInterface | {
+}, 'h1'>('h1')`
+  background: papayawhip;
+  color: hotpink;
+`;
+
 
 export default StyledSection;


### PR DESCRIPTION
As promised I took some time to improve the regex match for typescript interface sections. I also added some example interfaces to make sure the definitions are working correctly.

NOTE: I did not test these with [yats](https://github.com/HerringtonDarkholme/yats.vim), only with [vim-polyglot](https://github.com/sheerun/vim-polyglot).

- Allow inline typescript type definitions by allowing "{", "}", ":",
  ";", ",", "\s" and "\n" characters.
- Allow extension of or alternatives to interfaces by allowing "|" and
  "&" characters.
- Remove unsupported "`\k\+`" match of component name.
- Add typescript interface related syntax elements for enhanced inline
  highlighting.
- Add examples to test against.

Let me know, if I can help you further with anything.